### PR TITLE
glTF fixes and colours

### DIFF
--- a/mechanical/assembly_renderer.py
+++ b/mechanical/assembly_renderer.py
@@ -42,6 +42,7 @@ class PartDefinition:
         self.position = tuple(map(float, definition["position"].strip("()").split(",")))
         self.assembly_step = definition["assembly-step"]
         self.tags = definition.get("tags", [])
+        self.color = definition.get("color", "gray95")
 
 
 class AssemblyRederer:
@@ -71,10 +72,12 @@ class AssemblyRederer:
             for tag in part.tags:
                 cq_part = cq_part.tag(tag)
             #Pylint appears to be confused by the multimethod __init__ used by cq.Location
+
             assembly.add(
                 cq_part,
                 name=part.name,
-                loc=cq.Location(part.position) #pylint: disable=no-value-for-parameter
+                loc=cq.Location(part.position), #pylint: disable=no-value-for-parameter
+                color=cq.Color(part.color)
             )
 
         return assembly

--- a/nimble_orchestration/assembly_def_generator.py
+++ b/nimble_orchestration/assembly_def_generator.py
@@ -16,7 +16,13 @@ class AssemblyDefGenerator:
         self._parts = []
 
 
-    def add_part(self, name: str, step_file: str, position, assembly_step: str | None = None):
+    def add_part(
+        self,
+        name: str,
+        step_file: str,
+        position, assembly_step: str | None = None,
+        color: str | tuple | None = None
+    ):
         """
         Add a part to the assembly definition file.
         """
@@ -24,7 +30,8 @@ class AssemblyDefGenerator:
             "name": name,
             "step-file": step_file,
             "position": position,
-            "assembly-step": assembly_step
+            "assembly-step": assembly_step,
+            "color": color
         }
         self._parts.append(part)
 

--- a/nimble_orchestration/components.py
+++ b/nimble_orchestration/components.py
@@ -11,6 +11,7 @@ in a nimble rack.
 """
 from copy import copy, deepcopy
 
+
 class MechanicalComponent:
     """
     This is a generic class for any mechanical component. If it is a generic
@@ -123,11 +124,13 @@ class AssembledComponent:
                  key: str,
                  component: MechanicalComponent,
                  position: tuple,
-                 step: int):
+                 step: int,
+                 color: tuple | str = None):
         self._key = key
         self._component = component
         self._position = position
         self._step = step
+        self._color = color
 
     @property
     def key(self):
@@ -158,3 +161,10 @@ class AssembledComponent:
         The assembly step in which this component is assembled.
         """
         return self._step
+
+    @property
+    def color(self):
+        """
+        The color of this component.
+        """
+        return self._color

--- a/nimble_orchestration/configuration.py
+++ b/nimble_orchestration/configuration.py
@@ -129,7 +129,8 @@ class NimbleConfiguration:
                     key=key,
                     component=component,
                     position = (x_pos, y_pos, self._rack_params.base_plate_thickness),
-                    step=2
+                    step=2,
+                    color="gray82"
             )
         )
         return assembled_legs
@@ -207,7 +208,7 @@ class NimbleConfiguration:
             y_pos = -self._rack_params.rack_width / 2.0
             z_pos = z_offset + height_in_u * self._rack_params.mounting_hole_spacing
             tray_id = device.tray_id
-
+            color = 'dodgerblue1' if i%2 == 0 else 'deepskyblue1'
             component = GeneratedMechanicalComponent(
                 key=tray_id,
                 name=f"{device.name} tray",
@@ -229,7 +230,8 @@ class NimbleConfiguration:
                     key=f"tray_{i}",
                     component=component,
                     position = (x_pos, y_pos, z_pos),
-                    step=4
+                    step=4,
+                    color=color
                 )
             )
 
@@ -252,7 +254,8 @@ class NimbleConfiguration:
                 name=assembled_component.key,
                 step_file=assembled_component.component.step_representation,
                 position=assembled_component.position,
-                assembly_step=str(assembled_component.step)
+                assembly_step=str(assembled_component.step),
+                color=assembled_component.color
             )
 
         return assembly

--- a/nimble_orchestration/orchestration.py
+++ b/nimble_orchestration/orchestration.py
@@ -66,8 +66,8 @@ class OrchestrationRunner:
             description="assembly",
             output_files=[
                 "./assembly/assembly.stl",
-                # "./step/assembly.step",
-                "./assembly/assembly.gltf",
+                "./assembly/assembly.step",
+                "./assembly/assembly.glb",
             ],
             source_files=[os.path.join(REL_MECH_DIR, "assembly_renderer.py")],
             parameters={

--- a/server/nimble_server.py
+++ b/server/nimble_server.py
@@ -215,7 +215,7 @@ def read_item(number_of_units: float = 2, tray_width: float = 115, tray_depth: f
 
     ## NOTE that tray_width and tray_depth are no longer used after moving to tray_6in.py
     # Run the script with customized parameters
-    tray = cqgi_model_script("tray_6in.py", {"height_in_u": number_of_units, "shelf_type" = "generic"})
+    tray = cqgi_model_script("tray_6in.py", {"height_in_u": number_of_units, "shelf_type": "generic"})
 
     # In case there was an error
     if (type(tray).__name__ == "HTMLResponse"):


### PR DESCRIPTION
Assembly now uses a binary glTF (.glb) due to upstream bug with ACSII glTF. Adding colours to the glTF assembly so different components can be recognised.

Output now looks like this:
![image](https://github.com/Wakoma/nimble/assets/12807051/ef967cd5-8396-4522-9d38-f2d82d7a1901)

Colours can be adjusted later.