### PR TITLE
Add gitbuilding page for each shelf to main docs, add assembly glb to docs

### DIFF
--- a/documentation/construction.md
+++ b/documentation/construction.md
@@ -59,8 +59,7 @@ Make:
 
 ## Insert the remaining shelves {pagestep}
 
->!! **TODO**  
->!! Explain what order the assembled shelves are used.
+{{include: insert_shelves.md}}
 
 
-
+![](../build/assembly/assembly.glb)

--- a/mechanical/components/cadquery/tray_6in.py
+++ b/mechanical/components/cadquery/tray_6in.py
@@ -214,7 +214,7 @@ def hdd35_shelf(height_in_u) -> cad.Body:
 
 def dual_ssd_shelf(height_in_u) -> cad.Body:
     """
-    A shelf for atwo 2.5" SSDs
+    A shelf for two 2.5" SSDs
     """
     rack_params = nimble_builder.RackParameters()
     width = 70

--- a/nimble_orchestration/components.py
+++ b/nimble_orchestration/components.py
@@ -62,7 +62,7 @@ class MechanicalComponent:
     def stl_representation(self):
         """
         Return the path to the STL file that represents this part. Return None
-        if not defined
+        if not defined.
         """
         for output_file in self.output_files:
             if output_file.lower().endswith('stl'):

--- a/nimble_orchestration/orchestration.py
+++ b/nimble_orchestration/orchestration.py
@@ -90,10 +90,26 @@ class OrchestrationRunner:
             shutil.rmtree(DOCS_TMP_DIR)
         shutil.copytree(DOCS_DIR, DOCS_TMP_DIR)
 
+        sehlves_md = "* Insert the shelves into the rack in the following order "
+        sehlves_md += "(from top to bottom)\n"
+
         for shelf in configuration.shelves:
-            filename = os.path.join(DOCS_TMP_DIR, f"{shelf.device.id}_shelf.md")
+            md_file = f"{shelf.device.id}_shelf.md"
+            filename = os.path.join(DOCS_TMP_DIR, md_file)
             with open(filename, 'w', encoding="utf-8") as gb_file:
                 gb_file.write(shelf.md)
+            sehlves_md += "[Assembled "+shelf.name+"]("+md_file+"){make, qty:1, cat: prev}\n"
+
+        sehlves_md += "* Secure each in place with four [M4x10mm cap screws]{qty:"
+        sehlves_md += str(2*len(configuration.shelves))+", cat:mech}\n\n"
+
+        filename = os.path.join(DOCS_TMP_DIR, "insert_shelves.md")
+        with open(filename, 'w', encoding="utf-8") as gb_file:
+            gb_file.write(sehlves_md)
+
+
+        # Here we really need to be listhing the assembly stepes differently if the
+        # shelves are broad.
 
         self._run_gitbuilding()
 

--- a/nimble_orchestration/orchestration.py
+++ b/nimble_orchestration/orchestration.py
@@ -108,7 +108,7 @@ class OrchestrationRunner:
             gb_file.write(sehlves_md)
 
 
-        # Here we really need to be listhing the assembly stepes differently if the
+        # Here we really need to be listing the assembly steps differently if the
         # shelves are broad.
 
         self._run_gitbuilding()


### PR DESCRIPTION
A page for each shelf will now be in the main path of navigation of the documentation. The correct parts should be listed for printing and the assembly GLB is displayed on the construction page.