### PR TITLE
Started on an automated assembly step generator

### DIFF
--- a/mechanical/components/cadquery/assembly_step_generator.py
+++ b/mechanical/components/cadquery/assembly_step_generator.py
@@ -1,0 +1,70 @@
+import cadquery as cq
+from tray_6in import create_6in_shelf
+from cq_warehouse.fastener import SocketHeadCapScrew
+from device_placeholder import generate_placeholder
+
+def generate_assembly_step(device_id, json_config, exploded=True, annotated=True):
+    """
+    Generates an assembly showing the assembly step between a device
+    and a shelf, generated solely based on the device ID.
+    """
+
+    # Extract the device dimension information from the JSON object
+    length = float(json_config["LengthMm"].split(" ")[0])
+    depth = float(json_config["Depth"].split(" ")[0])
+    height = float(json_config["Height"].split(" ")[0])
+    height_in_units = int(json_config["HeightUnits"])
+
+    # Clean up shelf IDs that do not match the database
+    shelf_id = json_config["ShelfId"]
+    if shelf_id.startswith("raspi"):
+        shelf_id = "raspi"
+
+    # Generate the placeholder device so that the step can be built dynamically
+    device = generate_placeholder(device_id, length, depth, height)
+
+    # Generate the shelf for the given device
+    shelf = create_6in_shelf(shelf_id, height_in_units).cq()
+
+    # Generate an assembly with the device and shelf correctly positioned
+    assy = cq.Assembly()
+    assy.add(shelf, name="shelf", color=cq.Color(0.996, 0.867, 0.0, 1.0))
+    assy.add(device, name="device", color=cq.Color(0.565, 0.698, 0.278, 1.0))
+
+    # Set up constraints that will keep the device in the correct relationship to the shelf
+    assy.constrain("shelf", "Fixed")
+    assy.constrain("device@faces@>X", "shelf@faces@<Y[-2]", "Axis")
+    assy.constrain("device@faces@<Z", "shelf@faces@<Z[-3]", "Plane")
+    assy.solve()
+
+    from cadquery.vis import show
+    show(assy)
+
+
+def main():
+    """
+    Allows a user to run this as a command line utility.
+    Needs to be run from the root of the repository for
+    the JSON file to be found.
+    """
+
+    import json
+
+    # The device that the assembly step should be generated for 
+    device_id = "Raspberry_Pi_4B"
+
+    # Import and process the devices.json file
+    with open('devices.json') as json_file:
+        json_string = json_file.read()
+        devices_json = json.loads(json_string)
+
+        for cur_device in devices_json:
+            if cur_device["ID"] == device_id:
+                device = cur_device
+
+    # Call the code that generates the CAD models and assembly for the step
+    generate_assembly_step(device_id, device)
+
+
+if __name__ == "__main__":
+    main()

--- a/mechanical/components/cadquery/assembly_step_sample.py
+++ b/mechanical/components/cadquery/assembly_step_sample.py
@@ -1,0 +1,178 @@
+from mechanical.components.cadquery.tray_6in import create_6in_shelf
+import cadquery as cq
+from cadquery.vis import show
+from cq_annotate.views import explode_assembly
+from cq_annotate.callouts import add_assembly_lines
+
+
+def m2_5_screw(length=6.0):
+    """
+    Generates a simplified model of an M2.5 screw for the assembly.
+    """
+
+    # The threaded portion
+    screw = (
+        cq.Workplane()
+        .workplane(centerOption="CenterOfBoundBox")
+        .circle(2.5 / 2.0)
+        .extrude(length)
+    )
+
+    # Overall head shape
+    screw = (
+        screw.faces(">Z")
+        .circle(4.5 / 2.0)
+        .extrude(2.5)
+    )
+
+    # Add the hex drive cutout
+    screw = (
+        screw.faces(">Z")
+        .workplane(centerOption="CenterOfBoundBox")
+        .polygon(6, 2.0)
+        .cutBlind(-2.0)
+    )
+
+    # Tag the bottom face for an assembly line
+    screw.faces("<Z").tag("assembly_line")
+
+    return screw
+
+
+def assemble(explode=False, annotate=True, export_format="png", rpi=None):
+    """
+    Builds a sample assembly, explodes and annotates it.
+    """
+
+    # The top-level assembly
+    assy = cq.Assembly()
+
+    # Generate the shelf
+    shelf = create_6in_shelf("raspi", 1).cq()
+    assy.add(shelf, name="shelf", color=cq.Color(0.996, 0.867, 0.0, 1.0))
+
+    # Add the Raspberry Pi to the assembly
+    rpi = rpi.rotateAboutCenter((1, 0, 0), 90).rotateAboutCenter((0, 0, 1), -90)
+    # rpi.faces("<Z").tag("assembly_line")
+    assy.add(rpi, name="rpi",
+                  loc=cq.Location((-2.5, 24, 11)),
+                  color=cq.Color(0.565, 0.698, 0.278, 1.0),
+                  metadata={"explode_loc": cq.Location((0, 0, 30))},
+
+    )
+
+    # Add the mounting screws for the RPi
+    screw_length = 6.0
+    screw_starting_height = 1.0
+    screw_explode_height = 60.0
+    assy.add(
+        m2_5_screw(length=screw_length),
+        name="screw_1",
+        loc=cq.Location((-13.0, 23.5, screw_starting_height)),
+        color=cq.Color(0.04, 0.5, 0.67, 1.0),
+        metadata={"explode_loc": cq.Location((0, 0, screw_explode_height))},
+    )
+    assy.add(
+        m2_5_screw(length=screw_length),
+        name="screw_2",
+        loc=cq.Location((36.0, 23.5, screw_starting_height)),
+        color=cq.Color(0.04, 0.5, 0.67, 1.0),
+        metadata={"explode_loc": cq.Location((0, 0, screw_explode_height))},
+    )
+    assy.add(
+        m2_5_screw(length=screw_length),
+        name="screw_3",
+        loc=cq.Location((-13.0, 81.5, screw_starting_height)),
+        color=cq.Color(0.04, 0.5, 0.67, 1.0),
+        metadata={"explode_loc": cq.Location((0, 0, screw_explode_height))},
+    )
+    assy.add(
+        m2_5_screw(length=screw_length),
+        name="screw_4",
+        loc=cq.Location((36.0, 81.5, screw_starting_height)),
+        color=cq.Color(0.04, 0.5, 0.67, 1.0),
+        metadata={"explode_loc": cq.Location((0, 0, screw_explode_height))},
+    )
+
+    # Annotate with assembly lines, if requested
+    if annotate:
+        add_assembly_lines(assy, line_diameter=0.5)
+
+    # Created the exploded assembly, if requested
+    if explode:
+        explode_assembly(assy)
+
+    return assy
+
+
+if __name__ == "__main__":
+    # Import the Raspberry Pi STEP model
+    # We do this here and pass it because it is a very detailed step and takes awhile to load
+    # Downloaded from https://grabcad.com/library/raspberry-pi-4-model-b-1#!
+    rpi = cq.importers.importStep("/home/jwright/Downloads/raspberry_pi_4_model_b.step")
+
+    # Exploded and annotated Raspberry Pi shelf-component combo
+    assy = assemble(explode=True, annotate=True, rpi=rpi)
+
+    # Use the same options to export each image
+    png_opts = {
+        "width": 600,
+        "height": 600,
+        "camera_position": (65, -50, 75),
+        "view_up_direction": (0, 0, 1),
+        "focal_point": (20, 10, 35),
+        "parallel_projection": True,
+        "background_color": (1.0, 1.0, 1.0),
+        "clipping_range": (0, 400),
+    }
+    svg_opts = {
+        "width": 600,
+        "height": 600,
+        "marginLeft": 75,
+        "marginTop": 100,
+        "showAxes": False,
+        "projectionDir": (0.1, 0.1, 0.1),
+        "strokeWidth": 0.75,
+        "strokeColor": (225, 225, 225),
+        "hiddenColor": (0, 0, 255),
+        "showHidden": False,
+    }
+
+    # 01 - Export an annotated and exploded assembly step to PNG
+    assy.save("./build/images/01_exploded_and_annotated.png", opt=png_opts)
+
+    # 02 - Export an annotated and exploded assembly step to SVG
+    assy_compound = assy.toCompound()
+    cq.exporters.export(assy_compound.rotate((0, 0, 0), (1, 0, 0), -90), "./build/images/02_exploded_and_annotated.svg", opt=svg_opts)
+
+    # Exploded but not annotated Raspberry Pi shelf-component combo
+    assy = assemble(explode=True, annotate=False, rpi=rpi)
+
+    # 03 - Export an exploded but not annotated assembly step to PNG
+    assy.save("./build/images/03_exploded_but_not_annotated.png", opt=png_opts)
+
+    # 04 - Export an exploded but not annotated assembly step to SVG
+    assy_compound = assy.toCompound()
+    cq.exporters.export(assy_compound.rotate((0, 0, 0), (1, 0, 0), -90), "./build/images/04_exploded_but_not_annotated.svg", opt=svg_opts)
+
+    # Assembled with annotation lines
+    assy = assemble(explode=False, annotate=True, rpi=rpi)
+
+    # 05 - Export an assembled and annotated assembly step to PNG
+    assy.save("./build/images/05_assembled_and_annotated.png", opt=png_opts)
+
+    # 06 - Export an assembed and annotated assembly step to SVG
+    assy_compound = assy.toCompound()
+    cq.exporters.export(assy_compound.rotate((0, 0, 0), (1, 0, 0), -90), "./build/images/06_assembled_and_annotated.svg", opt=svg_opts)
+
+    # Plain, unannotated assembly
+    assy = assemble(explode=False, annotate=False, rpi=rpi)
+
+    # 07 - Export a plain assembled assembly step to PNG
+    assy.save("./build/images/07_assembled_plain.png", opt=png_opts)
+
+    # 06 - Export an assembed and annotated assembly step to SVG
+    assy_compound = assy.toCompound()
+    cq.exporters.export(assy_compound.rotate((0, 0, 0), (1, 0, 0), -90), "./build/images/08_assembled_plain.svg", opt=svg_opts)
+
+    # show(assy)

--- a/mechanical/components/cadquery/device_placeholder.py
+++ b/mechanical/components/cadquery/device_placeholder.py
@@ -1,0 +1,20 @@
+import cadquery as cq
+
+def generate_placeholder(device_name, length, depth, height):
+    """
+    Generates a generalized placeholder object for a device.
+    """
+
+    # Save the smallest dimension for things like filleting and text
+    smallest_dim = min(length, depth, height)
+
+    # The overall shape
+    placeholder = cq.Workplane().box(length, depth, height)
+
+    # Round the edges
+    placeholder = placeholder.edges().fillet(smallest_dim * 0.3)
+
+    # Add the text of what the device is to the top
+    placeholder = placeholder.faces(">Z").workplane(centerOption="CenterOfBoundBox").text(device_name, fontsize=6, distance=-smallest_dim * 0.1)
+
+    return placeholder

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ setup(
         'cadscript>=0.5.2',
         'exsource-tools',
         'cq-cli @ git+https://github.com/CadQuery/cq-cli.git',
-        'gitbuilding==0.15.0a2'
+        'gitbuilding==0.15.0a2',
+        'cq-annotate @ git+https://github.com/jmwright/cq-annotate.git',
+        'cq_warehouse @ git+https://github.com/gumyr/cq_warehouse.git',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
This is an attempt to generate assembly step CAD models/assemblies using the device ID from devices.json. The code generates a placeholder device based on the dimensions in the database, generates the matching shelf, then attempts to put them together.

There is still missing data in the database to make this fully automated. For instance, where are the mounting hole locations in the hardware, if there are any? There needs to be some way to know if there are screws involved, and if so, where they go.