### PR TITLE
Calculate shelf HightUnits from device Height if missing. Don't show devices that create invalid shelves in config

### DIFF
--- a/nimble_build_system/orchestration/configuration.py
+++ b/nimble_build_system/orchestration/configuration.py
@@ -41,7 +41,7 @@ class NimbleConfiguration(Configuration):
             all_devices = json.load(devices_file)
             def find_device(device_id):
                 return next((x for x in all_devices if x['ID'] == device_id), None)
-            selected_devices = [Device(find_device(x)) for x in selected_devices_ids]
+            selected_devices = [Device(find_device(x), self._rack_params) for x in selected_devices_ids]
 
         self._devices = deepcopy(selected_devices)
         self._shelves = self._generate_shelf_list

--- a/nimble_build_system/utils/gen_nimble_conf_options.py
+++ b/nimble_build_system/utils/gen_nimble_conf_options.py
@@ -106,7 +106,7 @@ def shelf_available(device):
         print(f"Warning: Invalid data in Height feild for {device['ID']}: ({device['Height']})")
         return False
 
-    #Neither Height or HeightUnits set. No shelf can be made.
+    # Neither Height or HeightUnits set. No shelf can be made.
     return False
 
 if __name__ == "__main__":


### PR DESCRIPTION
Pretty self explanatory from title.

* If HeightUnits isn't set we calculate the it from the height of the unit and the hole spacing.
* If neither Height or Height units is set then the device isn't listed in the server interface

Relates to #82 - Closes first 2 bullets. Doesn't close the others about special shelves.