### PR TITLE
Fix  to replace invalid characters

### DIFF
--- a/nimble_build_system/orchestration/device.py
+++ b/nimble_build_system/orchestration/device.py
@@ -66,7 +66,13 @@ class Device:
         """
         Return an key to identify the shelf.
         """
-        return f"shelf_h{self.height_in_u}_t{self.shelf_type.lower().replace(' ', '_')}"
+        def clean_name(name):
+            name = name.lower()
+            name = name.replace(' ', '_')
+            unsafe_char = re.findall(r'[a-zA-Z0-9-_]', name)
+            for char in set(unsafe_char):
+                name.replace(char, '')
+        return f"shelf_h{self.height_in_u}_--{clean_name(self.shelf_type)}"
 
     @property
     def shelf_builder_id(self):


### PR DESCRIPTION
Some shelves were not building due to characters such as `(` or `)` in the shelf key. This fixes that