### PR TITLE
Move to keyword only arguments to improve readability

### DIFF
--- a/nimble_build_system/cad/fasteners.py
+++ b/nimble_build_system/cad/fasteners.py
@@ -13,7 +13,16 @@ class Fastener:
     _fastener_type = "iso7380_1"
     _direction_axis = "-Z"
 
-    def __init__(self, name, position, explode_translation, size, fastener_type, direction_axis):
+    def __init__(
+        self,
+        name:str,
+        *,
+        position:tuple[float, float, float]=(0.0, 0.0, 0.0),
+        explode_translation:tuple[float, float, float]=(0.0, 0.0, 0.0),
+        size:str="M3-0.5",
+        fastener_type:str="iso7380_1",
+        direction_axis:str="-Z"
+    ):
         """
         Generic fastener constructor that sets common attributes for all faster types.
         """
@@ -80,15 +89,31 @@ class Screw(Fastener):
     """
     _length = 6  # mm
 
-    def __init__(self, name, position, explode_translation, size, fastener_type, axis, length):
+    def __init__(
+        self,
+        name:str,
+        *,
+        position:tuple[float, float, float]=(0.0, 0.0, 0.0),
+        explode_translation:tuple[float, float, float]=(0.0, 0.0, 0.0),
+        size:str="M3-0.5",
+        fastener_type:str="iso7380_1",
+        axis:str="-Z",
+        length:float=6.0
+    ):
         """
         Screw constructor that additionally sets the length of the screw.
         """
-        # pylint: disable=too-many-arguments
 
         self._length = length
 
-        super().__init__(name, position, explode_translation, size, fastener_type, axis)
+        super().__init__(
+            name,
+            position=position,
+            explode_translation=explode_translation,
+            size=size,
+            fastener_type=fastener_type,
+            direction_axis=axis
+        )
 
     @property
     def length(self):

--- a/nimble_build_system/cad/helpers.py
+++ b/nimble_build_system/cad/helpers.py
@@ -72,6 +72,7 @@ def cut_w_pattern(body: cad.Body,
                   size_y: cad.DimensionDefinitionType,
                   padding_x: float,
                   padding_y: float,
+                  *,
                   min_spacing: float = 0,
                   cut_depth: float = 10,
                   ) -> 'cad.Body':

--- a/nimble_build_system/cad/shelf.py
+++ b/nimble_build_system/cad/shelf.py
@@ -7,7 +7,6 @@ Rendering and documentation generation is also supported for the shelves.
 """
 
 # pylint: disable=unused-import
-# pylint: disable=too-many-positional-arguments
 
 import os
 import posixpath
@@ -135,7 +134,6 @@ class Shelf():
                  rack_params: RackParameters
                  ):
 
-        # pylint: disable=too-many-arguments
 
         self._rack_params = rack_params
 
@@ -821,10 +819,10 @@ class RaspberryPiShelf(Shelf):
         }
 
         super().__init__(device,
-                         assembly_key,
-                         position,
-                         color,
-                         rack_params)
+                         assembly_key=assembly_key,
+                         position=position,
+                         color=color,
+                         rack_params=rack_params)
 
 
     def generate_shelf_model(self):

--- a/nimble_build_system/cad/shelf.py
+++ b/nimble_build_system/cad/shelf.py
@@ -31,6 +31,7 @@ from nimble_build_system.orchestration.paths import REL_MECH_DIR
 
 
 def create_shelf_for(device_id: str,
+                     *,
                      assembly_key: str='Shelf',
                      position: tuple[float, float, float]=(0,0,0),
                      color: str='dodgerblue1',
@@ -75,10 +76,10 @@ def create_shelf_for(device_id: str,
         kwargs = {}
     return shelf_class(
             device,
-            assembly_key,
-            position,
-            color,
-            rack_params,
+            assembly_key=assembly_key,
+            position=position,
+            color=color,
+            rack_params=rack_params,
             **kwargs
     )
 
@@ -127,6 +128,7 @@ class Shelf():
 
     def __init__(self,
                  device: Device,
+                 *,
                  assembly_key: str,
                  position: tuple[float, float, float],
                  color: str,
@@ -516,13 +518,18 @@ class StuffShelf(Shelf):
     ##TODO: Perhaps make a "dummy" device for "stuff"?
     def __init__(self,
                  device: Device,
+                 *,
                  assembly_key: str,
                  position: tuple[float, float, float],
                  color: str,
                  rack_params: RackParameters,
                  thin: bool=False):
 
-        super().__init__(device, assembly_key, position, color, rack_params)
+        super().__init__(device,
+                         assembly_key=assembly_key,
+                         position=position,
+                         color=color,
+                         rack_params=rack_params)
         self.thin = thin
 
     def generate_shelf_model(self) -> cadscript.Body:
@@ -551,7 +558,7 @@ class NUCShelf(Shelf):
         builder = ShelfBuilder(
             self.height_in_u, width="broad", depth="standard", front_type="full"
         )
-        builder.cut_opening("<Y", builder.inner_width, 4)
+        builder.cut_opening("<Y", builder.inner_width, offset_y=4)
         builder.make_tray(sides="w-pattern", back="open")
         builder.add_mounting_hole_to_bottom(x_pos=0, y_pos=35, base_thickness=4, hole_type="M3cs")
         builder.add_mounting_hole_to_bottom(x_pos=0, y_pos=120, base_thickness=4, hole_type="M3cs")
@@ -569,7 +576,7 @@ class USWFlexShelf(Shelf):
             builder = ShelfBuilder(
                 self.height_in_u, width="standard", depth=119.5, front_type="full"
             )
-            builder.cut_opening("<Y", builder.inner_width, 4)
+            builder.cut_opening("<Y", builder.inner_width, offset_y=4)
             builder.make_tray(sides="w-pattern", back="open")
             # add 2 mounting bars on the bottom plate
             sketch = cadscript.make_sketch()
@@ -624,6 +631,7 @@ class AnkerShelf(Shelf):
     """
     def __init__(self,
                  device: Device,
+                 *,
                  assembly_key: str,
                  position: tuple[float, float, float],
                  color: str,
@@ -633,9 +641,11 @@ class AnkerShelf(Shelf):
                  internal_height: float = 25,
                  front_cutout_width: float = 53):
 
-        #pylint: disable=too-many-arguments
-
-        super().__init__(device, assembly_key, position, color, rack_params)
+        super().__init__(device,
+                         assembly_key=assembly_key,
+                         position=position,
+                         color=color,
+                         rack_params=rack_params)
         self.internal_width = internal_width
         self.internal_depth = internal_depth
         self.internal_height = internal_height

--- a/nimble_build_system/cad/shelf_builder.py
+++ b/nimble_build_system/cad/shelf_builder.py
@@ -38,9 +38,10 @@ class ShelfBuilder:
     def __init__(
         self,
         height_in_u: int,
-        width: Union[Literal["standard", "broad"], float],
-        depth: Union[Literal["standard"], float],
-        front_type: Literal["full", "open", "w-pattern", "slots"],
+        *,
+        width: Union[Literal["standard", "broad"], float] = "standard",
+        depth: Union[Literal["standard"], float] = "standard",
+        front_type: Literal["full", "open", "w-pattern", "slots"] = "full",
         base_between_beam_walls: Literal["none", "front-open", "closed"] = "closed",
         beam_wall_type: Literal["none", "standard", "ramp"] = "standard",
         rack_params=None,
@@ -399,6 +400,7 @@ class ShelfBuilder:
         self,
         face: str,
         size_x: cad.DimensionDefinitionType,
+        *,
         offset_y: float = 0,
         size_y: Optional[cad.DimensionDefinitionType] = None,
         depth: float = 999,
@@ -420,7 +422,8 @@ class ShelfBuilder:
         x_pos: float,
         y_pos: float,
         base_thickness: float,
-        hole_type: Literal["M3cs", "M3-tightfit", "base-only"],
+        *,
+        hole_type: Literal["M3cs", "M3-tightfit", "base-only"] = "M3-tightfit",
         base_diameter: float = 15,
     ) -> None:
         """
@@ -442,8 +445,9 @@ class ShelfBuilder:
         self,
         y_pos: float,
         z_pos: float,
-        hole_type: Literal["M3-tightfit", "HDD"],
-        side: Literal["left", "right", "both"],
+        *,
+        hole_type: Literal["M3-tightfit", "HDD"] = "M3-tightfit",
+        side: Literal["left", "right", "both"] = "both",
         base_diameter: float = 8,
     ) -> None:
         """
@@ -506,6 +510,7 @@ class ShelfBuilder:
         internal_width: float,
         internal_depth: float,
         internal_height: float = 0,
+        *,
         rear_cutout_width: float = 0,
         add_ziptie_channels: bool = True,
     ):
@@ -587,6 +592,7 @@ class ShelfBuilder:
 
 def ziptie_shelf(
     height_in_u: int,
+    *,
     internal_width: Optional[float] = None,
     internal_depth: Optional[float] = None,
     internal_height: Optional[float] = None,

--- a/py.pylintrc
+++ b/py.pylintrc
@@ -285,9 +285,9 @@ exclude-too-few-public-methods=
 # R0901)
 ignored-parents=
 
-## CHANGED FOM DEFAULT: increased due to the way we are passing parameters
+## CHANGED FOM DEFAULT: increased to allow lots of key word only-args
 # Maximum number of arguments for function / method.
-max-args=7
+max-args=10
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7


### PR DESCRIPTION
New pylint allows you to seperately set a maximum number of total aguments and a maximum number of positional arguments. This gave us lots of warnings on the number of functions that had a confusingly high number of arguments.

Rather than just up the limit in pylintrc it seems like good practice to make many of these arguments keyword only. This make code more clear, and more robust as we go forward.