### PR TITLE
Added wrapped zip ties to the assemblies

### DIFF
--- a/nimble_build_system/cad/rack_assembly.py
+++ b/nimble_build_system/cad/rack_assembly.py
@@ -17,7 +17,7 @@ class RackAssembly:
     """
     Holds the logic to assemble and render a Nimble rack in a step-by-step fashion.
     """
-    #pylint: disable=no-value-for-parameter
+
     def __init__(self, all_parts):
         # Allows us to collect the assembly parts for this configuration
         self.assembly_parts = {
@@ -39,6 +39,7 @@ class RackAssembly:
                                         shelf_obj.renders["assembled"]["render_options"])
 
                 # Make sure the shelves slide out of the rack when exploded
+                # pylint: disable=no-value-for-parameter
                 if shelf_obj.width_category == "broad":
                     explode_location = cq.Location((0, 0, 75))
                 else:
@@ -61,6 +62,7 @@ class RackAssembly:
 
                 # Handle the top and bottom plate explode locations differently
                 if "plate" in part.name and "top" in part.name:
+                    # pylint: disable=no-value-for-parameter
                     explode_location = cq.Location((0, 0, 20.0))
 
                     # Save this as the assembly's top plate
@@ -73,6 +75,7 @@ class RackAssembly:
                         "explode_location": explode_location
                     }
                 elif "plate" in part.name and "base" in part.name:
+                    # pylint: disable=no-value-for-parameter
                     explode_location = cq.Location((0, 0, 0.0))
 
                     # Save this as the assembly's base plate
@@ -85,6 +88,7 @@ class RackAssembly:
                         "explode_location": explode_location
                     }
                 elif "leg" in part.name:
+                    # pylint: disable=no-value-for-parameter
                     explode_location = cq.Location((0, 0, 20.0))
 
                     self.assembly_parts["legs"].append({
@@ -107,6 +111,7 @@ class RackAssembly:
         assembly = cq.Assembly()
 
         # Add the base plate
+        # pylint: disable=no-value-for-parameter
         assembly.add(
             self.assembly_parts["base_plate"]["component"],
             name="base_plate",
@@ -393,6 +398,8 @@ class RackAssembly:
             assembly_line_length = (assembly_line_length_extension +
                                         cur_screw.explode_translation[2])
 
+            # pylint: disable=no-value-for-parameter
+            # pylint: disable=too-many-function-args
             assembly.add(
                 cur_screw.fastener_model,
                 name=cur_screw.name,
@@ -449,6 +456,8 @@ class RackAssembly:
                             fastener_type="iso7380_1",
                             axis="Y",
                             length=10)
+            # pylint: disable=no-value-for-parameter
+            # pylint: disable=too-many-function-args
             assembly.add(
                 cur_screw.fastener_model,
                 name=cur_screw.name,
@@ -467,6 +476,7 @@ class RackAssembly:
         # Make sure that the already-assembled parts of the rack do not explode
         for part in assembly.children:
             if part.name not in names_to_still_explode:
+                # pylint: disable=no-value-for-parameter
                 part.metadata["explode_translation"] = cq.Location((0, 0, 0))
 
         return assembly

--- a/nimble_build_system/cad/rack_assembly.py
+++ b/nimble_build_system/cad/rack_assembly.py
@@ -17,7 +17,7 @@ class RackAssembly:
     """
     Holds the logic to assemble and render a Nimble rack in a step-by-step fashion.
     """
-
+    #pylint: disable=no-value-for-parameter
     def __init__(self, all_parts):
         # Allows us to collect the assembly parts for this configuration
         self.assembly_parts = {

--- a/nimble_build_system/cad/shelf.py
+++ b/nimble_build_system/cad/shelf.py
@@ -155,8 +155,8 @@ class Shelf():
             y_offset = 0.0
         elif self._device.width < self._device.depth:
             self._device_depth_axis = "Y"
-            x_offset = self._device.depth / 2.0
-            y_offset = 0.0
+            x_offset = 0.0
+            y_offset = self._device.depth / 2.0
         else:
             self._device_depth_axis = "X"
             x_offset = 0.0
@@ -173,19 +173,23 @@ class Shelf():
 
         self._fasteners = [
             Ziptie(name=None,
-                   position=(0, 28.75, 1.0),
-                   explode_translation=(0.0, 0.0, -40.0),
-                   size="4",
-                   fastener_type="ziptie",
-                   axis="-X",
-                   length=300),
+                  position=(0, 28.75, 1.0),
+                  explode_translation=(0.0, 0.0, -40.0),
+                  size="4",
+                  fastener_type="ziptie",
+                  axis="-X",
+                  length=300,
+                  wrapped_height=device_height + 2.0 + self._rack_params.tray_bottom_thickness,
+                  wrapped_width=115.0 - self._rack_params.tray_side_wall_thickness),
             Ziptie(name=None,
-                   position=(0, 86.25, 1.0),
-                   explode_translation=(0.0, 0.0, -40.0),
-                   size="4",
-                   fastener_type="ziptie",
-                   axis="-X",
-                   length=300),
+                  position=(0, 86.25, 1.0),
+                  explode_translation=(0.0, 0.0, -40.0),
+                  size="4",
+                  fastener_type="ziptie",
+                  axis="-X",
+                  length=300,
+                  wrapped_height=device_height + 2.0 + self._rack_params.tray_bottom_thickness,
+                  wrapped_width=115.0 - self._rack_params.tray_side_wall_thickness),
         ]
         self._renders = {"assembled":
                              {"order": 1,
@@ -448,6 +452,12 @@ class Shelf():
 
         # Add the fasteners to the assembly
         for i, fastener in enumerate(self._fasteners):
+            # Handle the state of the fastener, if that has been requested
+            if not render_options["explode"]:
+                fastener.state = "wrapped"
+            else:
+                fastener.state = "straight"
+
             # Get the CadQuery model for the fastener
             cur_fastener = fastener.fastener_model
 


### PR DESCRIPTION
This PR creates a simulation of wrapped zip ties for assemblies. @julianstirling @ericnitschke please let me know what you think.

Example:

![UniFi_Express_shelf_annotated](https://github.com/user-attachments/assets/e385d2e4-b9e9-4b3d-ad97-1dca61f1e63a)

![UniFi_Express_shelf_assembled](https://github.com/user-attachments/assets/148a251a-fb29-459f-84a8-6b689e4cb71f)

![final_assembly_base_and_legs_annotated](https://github.com/user-attachments/assets/63d203ef-a046-47fd-b64b-67f189beea6e)

![final_assembly_base_and_legs_assembled](https://github.com/user-attachments/assets/37320df4-cf17-47c1-a7f5-f3f579b9e3ea)

![final_assembly_standard_shelves_shelf_1_insertion_annotated](https://github.com/user-attachments/assets/e6b7f239-8d08-489b-adab-c681e60d72d9)

![final_assembly_standard_shelves_shelf_1_installed](https://github.com/user-attachments/assets/71ab6759-7044-4261-b05a-c1a5bdfa0a50)

![final_assembly_topplate_annotated](https://github.com/user-attachments/assets/b81fe008-9b94-42b0-95de-63acf8740450)

![final_assembly_topplate_assembled](https://github.com/user-attachments/assets/0dce40d2-5054-4717-9b7b-7fbe6bb809e4)
