### PR TITLE
Modified: gen_nimble_conf_options.py, added if statement filtering items.

### DIFF
--- a/nimble_build_system/utils/gen_nimble_conf_options.py
+++ b/nimble_build_system/utils/gen_nimble_conf_options.py
@@ -40,6 +40,11 @@ def main():
         if not shelf_available(device):
             #If a shelf cannot be made for this item then skip it
             continue
+        
+        # Added If statement filtering only '6 in' Rack label items, for hot fixing big boxes render issues."                                                                                                                             
+        if device['Rack'] != '6 in':
+            # This avois placing Racks different by '6 in' in the devices.json
+            continue
 
         item = {'value': device['ID'],
                 'name': device['Brand']+" "+device['Hardware']}


### PR DESCRIPTION
Modified: gen_nimble_conf_options.py, added if statement filtering all but 6 in, rack sizes, preventing oversized models in rendering.

Uses the '6 in' Rack label size. It depends on the Data Structure in the Data collector. (NocoDB). If the label changes, or more sizes are included in the build for any reason, the statement needs to be changed accordingly. Lines 44-47.

It fixes the issue of having big items not rendering, and not correlating to 6in form factor for nimble builds.

![Screenshot 2025-02-14 at 08-12-15 Configuration App](https://github.com/user-attachments/assets/ec4a922d-fbab-471b-a2ad-bf91649b938d)
