### PR TITLE
Fixed req cadquery-png-plugin to 1.0.2 and composer to build dockerfi…

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -21,6 +21,7 @@ services:
       - web
 
   nimble_cadorch_server:
+    build: .
     image: nimble_cadorch_server:latest   # your image
     container_name: nimble_cadorch_server
     restart: unless-stopped

--- a/generate_static.py
+++ b/generate_static.py
@@ -10,7 +10,7 @@ import os
 import json
 import logging
 import tempfile
-from cadorchestrator.generate import Generator
+from cadorchestrator.generate import Generator as NimbleGenerator
 from cadorchestrator.settings import Settings
 from nimble_build_system.orchestration.paths import ABS_PATH
 from nimble_build_system.cad.shelf import create_shelf_for
@@ -31,7 +31,7 @@ def Main():
     """
 
     components = GetComponentList()
-    Generator(components, Settings(), BUILD_DIR)
+    NimbleGenerator(components, Settings(), BUILD_DIR)
     OutputStaticSite(components['components'])
 
 

--- a/generate_static.py
+++ b/generate_static.py
@@ -10,7 +10,7 @@ import os
 import json
 import logging
 import tempfile
-from cadorchestrator.generate import Generator as NimbleGenerator
+from cadorchestrator.generate import Generator
 from cadorchestrator.settings import Settings
 from nimble_build_system.orchestration.paths import ABS_PATH
 from nimble_build_system.cad.shelf import create_shelf_for
@@ -31,7 +31,7 @@ def main():
     """
 
     components = get_component_list()
-    NimbleGenerator(components, Settings(), BUILD_DIR)
+    Generator.run(components, Settings(), BUILD_DIR)
     output_static_site(components['components'])
 
 

--- a/generate_static.py
+++ b/generate_static.py
@@ -16,7 +16,7 @@ from nimble_build_system.orchestration.paths import ABS_PATH
 from nimble_build_system.cad.shelf import create_shelf_for
 
 
-BUILD_DIR = ABS_PATH 
+BUILD_DIR = ABS_PATH
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -24,18 +24,18 @@ logging.basicConfig(
     force=True)
 
 
-def Main():
+def main():
     """
     Main script function. Gets a list of printed components (legs and shelves)
     and uses the orchestration runner to build them
     """
 
-    components = GetComponentList()
+    components = get_component_list()
     NimbleGenerator(components, Settings(), BUILD_DIR)
-    OutputStaticSite(components['components'])
+    output_static_site(components['components'])
 
 
-def TempDir():
+def temp_dir():
     """
     Creates a directory under temporary file system:
         in Linux at: "/tmp/"
@@ -51,7 +51,7 @@ def TempDir():
     return location
 
 
-def GetComponentList():
+def get_component_list():
     """
     Generate the component list. This is 4 types of legs and some
     shelves
@@ -74,7 +74,7 @@ def GetComponentList():
     return {'device-ids':component_list, 'components':components}
 
 
-def OutputStaticSite(components):
+def output_static_site(components):
     """
     Create a sumple web page (index.html) with links to all generated files
     """
@@ -120,4 +120,4 @@ def OutputStaticSite(components):
 
 
 if __name__ == "__main__":
-    Main()
+    main()

--- a/nimble_build_system/utils/gen_nimble_conf_options.py
+++ b/nimble_build_system/utils/gen_nimble_conf_options.py
@@ -8,15 +8,18 @@ import os
 import sys
 import json
 import re
+from nimble_devices_updater import main as update_devices_json
+
 
 def usage():
     """
     Prints a usage message for this utility.
     """
+    print("gen_nimble_conf_options")
     print("This utility exists to generate config options for CadOrchestrator")
     print("using devices.json")
     print("Usage:")
-    print("    gen_nimble_conf_options")
+
 
 def main():
     """
@@ -26,10 +29,21 @@ def main():
 
     if not os.path.exists('devices.json'):
         print("Error. devices.json not found")
+        print("Attempting to update devices.json from remote source...")
+        try:
+            update_devices_json()
+            print("devices.json updated successfully.")
+        except Exception as e:
+            print(f"Failed to update devices.json: {e}")
         sys.exit(1)
-    # Write the JSON data to file
+    
+    usage()
+
+    # Write the JSON data to a file.
     with open('devices.json', 'r', encoding="utf-8") as dev_file:
         devices = json.load(dev_file)
+
+
 
     access_points = []
     routers = []
@@ -52,10 +66,13 @@ def main():
 
         # Added If statement filtering only '6 in' Rack label items,
         # fixing big boxes with render issues.
-        if device['Rack'] != '6 in':
-            # This avois placing Racks different by '6 in' in the devices.json
-            continue
-
+        allowed = ['6in']
+        print("Allowed device sizes: ",allowed)
+        
+        for dev in allowed:
+            if dev in device['Rack'] != dev:
+                continue
+        
         item = {'value': device['ID'],
                 'name': device['Brand']+" "+device['Hardware']}
         if device['Type'] in ["Access Point", "Router + AP"]:
@@ -97,9 +114,12 @@ def main():
         }
     ]}
 
+    print(f"Generated config options for {len(access_points)+len(routers)+len(servers)+len(switches)} devices.")
+
     with open('OrchestratorConfigOptions.json', 'w', encoding="utf-8") as conf_file:
         json.dump(conf_dict, conf_file)
 
+    print("Wrote OrchestratorConfigOptions.json")
 
 def shelf_available(device):
     """

--- a/nimble_build_system/utils/gen_nimble_conf_options.py
+++ b/nimble_build_system/utils/gen_nimble_conf_options.py
@@ -8,7 +8,7 @@ import os
 import sys
 import json
 import re
-from nimble_devices_updater import main as update_devices_json
+from .nimble_devices_updater import main as update_devices_json
 
 
 def usage():

--- a/nimble_build_system/utils/gen_nimble_conf_options.py
+++ b/nimble_build_system/utils/gen_nimble_conf_options.py
@@ -33,10 +33,10 @@ def main():
         try:
             update_devices_json()
             print("devices.json updated successfully.")
-        except Exception as e:
+        except RuntimeError as e:
             print(f"Failed to update devices.json: {e}")
         sys.exit(1)
-    
+
     usage()
 
     # Write the JSON data to a file.
@@ -68,11 +68,11 @@ def main():
         # fixing big boxes with render issues.
         allowed = ['6in']
         print("Allowed device sizes: ",allowed)
-        
+
         for dev in allowed:
-            if dev in device['Rack'] != dev:
+            if device['Rack'] != dev:
                 continue
-        
+
         item = {'value': device['ID'],
                 'name': device['Brand']+" "+device['Hardware']}
         if device['Type'] in ["Access Point", "Router + AP"]:
@@ -114,7 +114,8 @@ def main():
         }
     ]}
 
-    print(f"Generated config options for {len(access_points)+len(routers)+len(servers)+len(switches)} devices.")
+    print(f"Generated config options for \
+          {len(access_points)+len(routers)+len(servers)+len(switches)} devices.")
 
     with open('OrchestratorConfigOptions.json', 'w', encoding="utf-8") as conf_file:
         json.dump(conf_dict, conf_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ attrs==25.3.0
 backports-datetime-fromisoformat==2.0.3
 blinker==1.9.0
 Brotli==1.1.0
-cadorchestrator @ git+https://gitlab.com/gitbuilding/cadorchestrator.git@a0bbf009b968970add7e3574497298c109e8ce3f
+cadorchestrator @ git+https://gitlab.com/gitbuilding/cadorchestrator.git@master
 cadquery==2.4.0
 cadquery-ocp==7.7.2.2b2
 cadquery_freecad_import_plugin>=1.0.0
-cadquery_png_plugin>=1.0.2
+cadquery_png_plugin==1.0.2
 cadscript>=0.5.3
 casadi>=3.7.1
 certifi==2025.8.3


### PR DESCRIPTION
Fixing a bug that will prevent cadorchestrator using cadquery to fail test at render time due to a change in cadquery-png-plugin.

Fixing an issue on Docker compose that wouldn't build the dockerfile image for nimble/cadorchestrator.

solution:

Adding on requirements.txt the png plugin package to a previous working version. (1.0.2)

Modifying the docker-compose.yaml adding build option.